### PR TITLE
Fix shebang, when Python 3 is system default.

### DIFF
--- a/nvidia-top
+++ b/nvidia-top
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python2
 
 import subprocess as sp
 import xml.etree.ElementTree as ET


### PR DESCRIPTION
Fix shebang, when Python 3 is system default. 