### PR TITLE
Revert "added minimal window width test"

### DIFF
--- a/nvidia-top
+++ b/nvidia-top
@@ -108,12 +108,10 @@ if __name__ == '__main__':
 
     scr = crs.initscr()
     scr.keypad(1)
-    win_max = scr.getmaxyx()
+    
     try:
         
         width = 94
-        if width > win_max[1]:
-            raise Exception('terminal too small')
         
         data = sp.check_output(['nvidia-smi', '-q', '-x'])
         root = ET.fromstring(data)


### PR DESCRIPTION
Reverts abhishekbajpayee/nvidia-top#7

Not sure if this is super useful. Resizing the window should fix the output. Also, when I run with this change in a small window, I don't see any error message because the exception isn't caught anywhere.